### PR TITLE
docs(sharec): README misspell fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ projects, keep your code up to date and starts new projects in one command.
 ```shell
 npm add sharec
 ```
-3. Add `posintall` and `uninstall` scripts to root `package.json` file:
+3. Add `postinstall` and `preuninstall` scripts to root `package.json` file:
 ```json
 "scripts": {
   "postinstall": "sharec install",


### PR DESCRIPTION
I think there's been a little mistake. I tried to fix it:

> Add `posintall` and `uninstall` scripts to root package.json file:

↓ 

> Add **`postinstall`** and **`preuninstall`** scripts to root package.json file: