### PR TITLE
fix(schema): the cli parser is supporting the operators `||` and `;`

### DIFF
--- a/packages/sharec-schema/lib/helpers/commandsToMap.js
+++ b/packages/sharec-schema/lib/helpers/commandsToMap.js
@@ -28,7 +28,7 @@ function commandsToMap(params) {
       })
     }
 
-    const splittedCommand = params[key].split(/(\||&{1,2})/).map(trim)
+    const splittedCommand = params[key].split(/([&|]{1,2}|;)/).map(trim)
 
     for (let i = 0; i < splittedCommand.length; i++) {
       const command = splittedCommand[i]

--- a/packages/sharec-schema/lib/helpers/test/commandsToMap.test.js
+++ b/packages/sharec-schema/lib/helpers/test/commandsToMap.test.js
@@ -131,4 +131,66 @@ describe('strategies > helpers > params > commandsToMap', () => {
       ]),
     })
   })
+
+  it('should handle the logical operator or', () => {
+    expect(
+      commandsToMap({
+        current: 'npx fixpack || true',
+      }),
+    ).toEqual({
+      current: new Map([
+        [
+          'npx',
+          [
+            new Map([
+              ['separator', '||'],
+              ['env', []],
+              ['args', ['fixpack']],
+            ]),
+          ],
+        ],
+        [
+          'true',
+          [
+            new Map([
+              ['separator', null],
+              ['env', []],
+              ['args', []],
+            ]),
+          ],
+        ],
+      ]),
+    })
+  })
+
+  it('should handle the command separator', () => {
+    expect(
+      commandsToMap({
+        current: 'fixpack; husky install',
+      }),
+    ).toEqual({
+      current: new Map([
+        [
+          'fixpack',
+          [
+            new Map([
+              ['separator', ';'],
+              ['env', []],
+              ['args', []],
+            ]),
+          ],
+        ],
+        [
+          'husky',
+          [
+            new Map([
+              ['separator', null],
+              ['env', []],
+              ['args', ['install']],
+            ]),
+          ],
+        ],
+      ]),
+    })
+  })
 })


### PR DESCRIPTION
This PR is fixing the issue #216.
I've also added the support for the command separator `;`.